### PR TITLE
Update atom-utils to version 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": ">=0.140.0"
   },
   "dependencies": {
-    "atom-utils": "0.0.1",
+    "atom-utils": ">=0.6.3",
     "event-kit": "^0.8.0",
     "lodash": "^2.4.1",
     "space-pen": "^3.8.0"


### PR DESCRIPTION
This will fix the issues with latest Atom version that now uses native promises in `activatePackage`.