### PR TITLE
Remove styles for tree-view-resizer

### DIFF
--- a/styles/tree-view-open-files.less
+++ b/styles/tree-view-open-files.less
@@ -1,11 +1,5 @@
 @import "ui-variables";
 
-.tree-view-resizer {
-	display: -webkit-flex !important;
-	flex-direction: column;
-	align-items: stretch;
-}
-
 .tree-view-open-files {
 	> .list-tree {
 		width: 100%;
@@ -18,6 +12,7 @@
 	overflow: auto;
 	flex: 0 0 1;
 	position: relative;
+	order: 0;
 
 	.close-open-file {
 		background: none;


### PR DESCRIPTION
Once atom/tree-view#579 will be merged the tree-view will use a flex layout by default, so this won't be necessary.

Also, the fact that you use `!important` for the display property break a fix introduced in the tree-view to force a redraw of the scrollbars when the Atom themes are changed (by toggling the visibility of the tree-view sing a `display: none`).