### PR TITLE
Fix open files visibility after toggling tree-view

### DIFF
--- a/lib/tree-view-open-files.coffee
+++ b/lib/tree-view-open-files.coffee
@@ -20,9 +20,9 @@ module.exports =
 
 			atom.commands.add 'atom-workspace', 'tree-view:toggle', =>
 				if treeView.treeView?.is(':visible')
-					@treeViewOpenFilesView.show()
-				else
 					@treeViewOpenFilesView.hide()
+				else
+					@treeViewOpenFilesView.show()
 
 			atom.commands.add 'atom-workspace', 'tree-view:show', =>
 				@treeViewOpenFilesView.show()


### PR DESCRIPTION
This simply reverses which commands are run as the result of the treeView visibility 'if' condition. 
Fixes #27.
