### PR TITLE
Order of sidebar opened file list in sync with the tab order

### DIFF
--- a/lib/tree-view-open-files-pane-view.coffee
+++ b/lib/tree-view-open-files-pane-view.coffee
@@ -53,7 +53,7 @@ class TreeViewOpenFilesPaneView
 			listItemName.setAttribute('data-path', item.getPath?())
 			listItemName.setAttribute('data-name', item.getTitle?())
 			listItem.appendChild listItemName
-			@container.appendChild listItem
+			@container.insertBefore(listItem, @activeEntry?.nextSibling);
 			if item.onDidChangeTitle?
 				titleSub = item.onDidChangeTitle =>
 					@updateTitle item
@@ -71,6 +71,11 @@ class TreeViewOpenFilesPaneView
 
 		@paneSub.add pane.onDidRemoveItem ({item}) =>
 			@removeEntry item
+
+		@paneSub.add pane.onDidMoveItem ({item, oldIndex, newIndex}) =>
+			movedEntry = @entryForItem item
+			@container.removeChild(movedEntry.element)
+			@container.insertBefore(movedEntry.element, @container.children[newIndex]);
 
 		@paneSub.add pane.onDidDestroy => @paneSub.dispose()
 


### PR DESCRIPTION
1. Opening new file will add the entry on the sidebar right next to currently selected entry (insertBefore) , instead of adding it at the last (appendChild)
2. Moving the tab of opened files (either by mouse, or using key-binding), will reorder the entries of opened file in the sidebar, in same order as the tabs. 

These will enable a proper mapping between the order of the open files tabs and their corresponding entries in the sidebar.
