### PR TITLE
Use "browser" icon for panes

### DIFF
--- a/lib/tree-view-open-files-pane-view.coffee
+++ b/lib/tree-view-open-files-pane-view.coffee
@@ -19,7 +19,7 @@ class TreeViewOpenFilesPaneView
 		header.classList.add('list-item')
 
 		headerSpan = document.createElement('span')
-		headerSpan.classList.add('name', 'icon', 'icon-file-directory')
+		headerSpan.classList.add('name', 'icon', 'icon-browser')
 		headerSpan.setAttribute('data-name', 'Pane')
 		headerSpan.innerText = 'Pane'
 		header.appendChild headerSpan


### PR DESCRIPTION
Using "browser" icon (rectangle with small squares in upper-left) visually distinguishes panes from the folders directly below them and allows you to more quickly locate what you're looking for.