### PR TITLE
Fix jQuery-isms that are removed in Atom 1.16

### DIFF
--- a/lib/tree-view-open-files-view.coffee
+++ b/lib/tree-view-open-files-view.coffee
@@ -54,5 +54,5 @@ class TreeViewOpenFilesView
 
 	show: ->
 		requirePackages('tree-view').then ([treeView]) =>
-			treeView.treeView.find('.tree-view-scroller').css 'background', treeView.treeView.find('.tree-view').css 'background'
-			treeView.treeView.prepend @element
+			treeView.treeView.scroller.style.background = getComputedStyle(treeView.treeView.element).background
+			treeView.treeView.element.insertBefore(@element, treeView.treeView.element.firstChild)

--- a/lib/tree-view-open-files.coffee
+++ b/lib/tree-view-open-files.coffee
@@ -19,7 +19,7 @@ module.exports =
 				@treeViewOpenFilesView.show()
 
 			atom.commands.add 'atom-workspace', 'tree-view:toggle', =>
-				if treeView.treeView?.is(':visible')
+				if treeView.treeView?.isVisible()
 					@treeViewOpenFilesView.show()
 				else
 					@treeViewOpenFilesView.hide()


### PR DESCRIPTION
This seems to work for me, and should fix #49 .

I am not 100% sure that the intent is of changing the background colour on the tree view scroller element; it seems to have no practical visual effect. But I *think* my code does the same as the original.